### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
   schedule:
     - cron: "0 * * * *" # Run every hour
 
+permissions:
+  contents: read
+  pull-requests: write
+  actions: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/FongMi-TV-Actions-Builder/security/code-scanning/1](https://github.com/xixu-me/FongMi-TV-Actions-Builder/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `pull-requests: write` if the workflow needs to interact with pull requests (not explicitly seen in the provided code but included as a precaution).
- `actions: write` for managing workflow artifacts and statuses.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions to that specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
